### PR TITLE
fix: pyright error on Github Actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,8 +37,18 @@ jobs:
       run: |
         pip install -e ".[dev]"
 
+    - name: Create pyrightconfig.json
+      run: |
+        echo '{
+          "exclude": [
+            "src/lpsim/env/**"
+          ],
+          "typeCheckingMode": "basic"
+        }' > pyrightconfig.json
+
     - name: Run type check
       run: |
+        pyright --version
         pyright .
 
     - name: Run tests with coverage


### PR DESCRIPTION
Pyright use standard by default and report thousands of errors. Also to ignore RL codes, which need to install more packages.